### PR TITLE
[FIX] l10n_ec_account_edi: evaluate correct response from SRI to auto…

### DIFF
--- a/l10n_ec_account_edi/models/account_edi_document.py
+++ b/l10n_ec_account_edi/models/account_edi_document.py
@@ -596,12 +596,12 @@ class AccountEdiDocument(models.Model):
         si fue devuelta, devolver False los mensajes
         si fue recibida, devolver True y los mensajes
         """
-        ok = False
+        is_auth = False
         msj_list = []
         response_data = serialize_object(response, dict)
         if not response_data or not response_data.get("autorizaciones"):
             _logger.warning("Authorization response error, No Autorizacion in response")
-            return ok, msj_list
+            return is_auth, msj_list
         # a veces el SRI devulve varias autorizaciones, unas como no autorizadas
         # pero otra si autorizada, si pasa eso, tomar la que fue autorizada
         # las demas ignorarlas
@@ -620,9 +620,9 @@ class AccountEdiDocument(models.Model):
                 msj_list.append(msj_str)
             estado = doc.get("estado")
             if estado != "AUTORIZADO":
-                ok = False
+                is_auth = False
                 continue
-            ok = True
+            is_auth = True
             msj_list = []
             # tomar la fecha de autorizacion que envia el SRI
             l10n_ec_authorization_date = doc.get("fechaAutorizacion")
@@ -642,7 +642,7 @@ class AccountEdiDocument(models.Model):
                 {"l10n_ec_authorization_date": l10n_ec_authorization_date.strftime(DTF)}
             )
             break
-        return ok, msj_list
+        return is_auth, msj_list
 
     def _l10n_ec_get_info_debit_note(self):
         self.ensure_one()

--- a/l10n_ec_account_edi/models/account_edi_format.py
+++ b/l10n_ec_account_edi/models/account_edi_format.py
@@ -253,7 +253,7 @@ class AccountEdiFormat(models.Model):
                         continue
                     # intentar consultar el documento previamente autorizado
                     is_auth = False
-                    ok = False
+                    is_sent = False
                     msj = []
                     if edi_doc.l10n_ec_last_sent_date:
                         sri_res = edi_doc._l10n_ec_edi_send_xml_auth(auth_client)
@@ -263,15 +263,19 @@ class AccountEdiFormat(models.Model):
                         errors.extend(msj)
                     if not is_auth:
                         sri_res = edi_doc._l10n_ec_edi_send_xml(client_send, xml_signed)
-                        ok, msj = edi_doc._l10n_ec_edi_process_response_send(sri_res)
+                        is_sent, msj = edi_doc._l10n_ec_edi_process_response_send(
+                            sri_res
+                        )
                         errors.extend(msj)
-                    if not is_auth and ok and not msj:
+                    if not is_auth and is_sent and not msj:
                         # guardar la fecha de envio al SRI
                         # en caso de errores, poder saber si hubo un intento o no
                         # para antes de volver a enviarlo, consultar si se autorizo
                         edi_doc.write({"l10n_ec_last_sent_date": datetime.now()})
                         sri_res = edi_doc._l10n_ec_edi_send_xml_auth(auth_client)
-                        ok, msj = edi_doc._l10n_ec_edi_process_response_auth(sri_res)
+                        is_auth, msj = edi_doc._l10n_ec_edi_process_response_auth(
+                            sri_res
+                        )
                         errors.extend(msj)
             except Exception as ex:
                 _logger.error(tools.ustr(traceback.format_exc()))
@@ -287,7 +291,7 @@ class AccountEdiFormat(models.Model):
             res.update(
                 {
                     document: {
-                        "success": not errors and True or False,
+                        "success": True if not errors and is_auth else False,
                         "error": "".join(errors),
                         "attachment": attachment,
                         "blocking_level": blocking_level,


### PR DESCRIPTION
…rize document

Before this commit, sometimes SRI give response without messages and  document is not authorized, but into odoo only is evaluate if has messages so document is changed to success(it is wrong) after this commit, now we evaluated SRI response estado == AUTORIZADO to change a success.
BONUS: better variable name to clarify to is_auth and is_sent instead of ok