### PR TITLE
[IMP] l10n_ec_account_edi: add edi_authorization head in xml

### DIFF
--- a/l10n_ec_account_edi/__manifest__.py
+++ b/l10n_ec_account_edi/__manifest__.py
@@ -14,6 +14,7 @@
     "data": [
         "security/ir.model.access.csv",
         "data/edi_format_data.xml",
+        "data/edi_templates/edi_authorization.xml",
         "data/edi_templates/edi_info_tributaria_data.xml",
         "data/edi_templates/edi_invoice.xml",
         "data/edi_templates/edi_liquidation.xml",

--- a/l10n_ec_account_edi/data/edi_templates/edi_authorization.xml
+++ b/l10n_ec_account_edi/data/edi_templates/edi_authorization.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<odoo>
+    <template id="ec_edi_authorization">
+        <RespuestaAutorizacion>
+            <estado>AUTORIZADO</estado>
+            <numeroAutorizacion t-out="authorization_number" />
+            <fechaAutorizacion t-out="authorization_date" />
+            <ambiente t-out='environment' />
+            <comprobante t-out="xml_file" />
+        </RespuestaAutorizacion>
+    </template>
+</odoo>

--- a/l10n_ec_account_edi/models/account_edi_document.py
+++ b/l10n_ec_account_edi/models/account_edi_document.py
@@ -726,3 +726,18 @@ class AccountEdiDocument(models.Model):
             ]
         )
         account_moves_with_final_consumer.write({"is_move_sent": True})
+
+    def _l10n_ec_create_file_authorized(
+        self, xml_file, authorization_number, authorization_date, environment
+    ):
+        ViewModel = self.env["ir.ui.view"].sudo()
+        xml_values = {
+            "xml_file": xml_file,
+            "authorization_number": authorization_number,
+            "authorization_date": authorization_date.strftime(DTF),
+            "environment": "PRODUCCION" if environment == "production" else "PRUEBAS",
+        }
+        xml_authorized = ViewModel._render_template(
+            "l10n_ec_account_edi.ec_edi_authorization", xml_values
+        )
+        return xml_authorized


### PR DESCRIPTION
agrega en modelo account.edi.document una nueva función _l10n_ec_create_file_authorized(

        self, xml_file, authorization_number, authorization_date, environment
    ):

util para agregar el encabezado del estado de la autorización a un documento xml

los parametros a usar son:

xml_file: documento xml
authorization_number: Número de autorización
authorization_date: Fecha de autorización
environment: ambiente "production" or "test"