### PR TITLE
15.0 cancelled

### DIFF
--- a/l10n_ec_account_edi/models/account_edi_document.py
+++ b/l10n_ec_account_edi/models/account_edi_document.py
@@ -516,7 +516,7 @@ class AccountEdiDocument(models.Model):
         Enviar a validar el comprobante con la clave de acceso
         :param client_ws: instancia del webservice para realizar el proceso
         """
-        response = False
+        response = {}
         try:
             # el parametro xml del webservice espera recibir xs:base64Binary
             # con suds nosotros haciamos la conversion
@@ -546,11 +546,12 @@ class AccountEdiDocument(models.Model):
         """
         msj_list = []
         response_data = serialize_object(response, dict)
-        ok = response_data.get("estado", "") == "RECIBIDA"
-        if response_data.get("estado", "") == "DEVUELTA":
-            # si fue devuelta intentar nuevamente
-            ok = False
+
         try:
+            ok = response_data.get("estado", "") == "RECIBIDA"
+            if response_data.get("estado", "") == "DEVUELTA":
+                # si fue devuelta intentar nuevamente
+                ok = False
             comprobantes = (response_data.get("comprobantes") or {}).get(
                 "comprobante"
             ) or []
@@ -569,7 +570,7 @@ class AccountEdiDocument(models.Model):
         except Exception as e:
             msj_list.append(tools.ustr(e))
             _logger.info(
-                "can't validate document, claveAcceso %s. ERROR: %s TRACEBACK: %s",
+                "can't validate document, clave de acceso %s. ERROR: %s TRACEBACK: %s",
                 self.l10n_ec_xml_access_key,
                 tools.ustr(e),
                 tools.ustr(traceback.format_exc()),

--- a/l10n_ec_account_edi/tests/__init__.py
+++ b/l10n_ec_account_edi/tests/__init__.py
@@ -7,3 +7,4 @@ from . import test_l10n_ec_edi_liquidation
 from . import test_l10n_ec_edi_credit_note
 from . import test_l10n_ec_edi_debit_note
 from . import test_l10n_ec_mail
+from . import test_l10n_ec_cancelled

--- a/l10n_ec_account_edi/tests/test_edi_common.py
+++ b/l10n_ec_account_edi/tests/test_edi_common.py
@@ -1,7 +1,9 @@
 import base64
 from datetime import datetime
 
+import mock.mock
 import pytz
+from zeep import Client
 
 from odoo.tests import tagged
 from odoo.tools import misc, os
@@ -192,3 +194,12 @@ class TestL10nECEdiCommon(AccountEdiTestCommon, TestL10nECCommon):
             "mensajes": None,
             "comprobante": xml_file,
         }
+
+    def _get_response_reception_received(self):
+        return {"estado": "RECIBIDA", "comprobantes": None}
+
+    def _zeep_client_ws_sri(self):
+        mock_client = mock.mock.create_autospec(Client)
+        mock_service = mock_client.service
+        mock_service.some_method.return_value = "Mocked response"
+        return mock_client

--- a/l10n_ec_account_edi/tests/test_l10n_ec_cancelled.py
+++ b/l10n_ec_account_edi/tests/test_l10n_ec_cancelled.py
@@ -1,0 +1,136 @@
+from unittest.mock import patch
+
+from odoo.exceptions import ValidationError
+from odoo.tests import tagged
+
+from odoo.addons.l10n_ec_account_edi.models.account_edi_document import (
+    AccountEdiDocument,
+)
+from odoo.addons.l10n_ec_account_edi.models.account_edi_format import AccountEdiFormat
+
+from .test_edi_common import TestL10nECEdiCommon
+
+
+@tagged("post_install_l10n", "post_install", "-at_install", "cancelled")
+class TestL10nCancelled(TestL10nECEdiCommon):
+    def test_l10n_ec_authorized_to_cancelled_ok(self):
+        """
+        Create invoice, send to the SRI for authorize and successful cancelled
+        """
+
+        def mock_l10n_ec_edi_zeep_client(edi_doc_instance, environment, url_type):
+            return self._zeep_client_ws_sri()
+
+        def mock_l10n_ec_response_reception_received(
+            edi_doc_instance, client_ws, xml_signed
+        ):
+            return self._get_response_reception_received()
+
+        def mock_l10n_ec_edi_send_xml_with_auth(edi_doc_instance, client_ws):
+            return self._get_response_with_auth(edi_doc_instance)
+
+        def mock_l10n_ec_edi_process_response_auth_cancelled(instance, response):
+            is_auth = False
+            msj_list = []
+            return is_auth, msj_list
+
+        partner = self.partner_with_email
+        self._setup_edi_company_ec()
+        invoice = self._l10n_ec_prepare_edi_out_invoice(
+            partner=partner, auto_post=False
+        )
+        invoice.action_post()
+        edi_doc = invoice._get_edi_document(self.edi_format)
+
+        # for authorize
+        with patch.object(
+            AccountEdiFormat,
+            "_l10n_ec_get_edi_ws_client",
+            mock_l10n_ec_edi_zeep_client,
+        ), patch.object(
+            AccountEdiDocument,
+            "_l10n_ec_edi_send_xml_auth",
+            mock_l10n_ec_edi_send_xml_with_auth,
+        ), patch.object(
+            AccountEdiDocument,
+            "_l10n_ec_edi_send_xml",
+            mock_l10n_ec_response_reception_received,
+        ):
+            edi_doc._process_documents_web_services(with_commit=False)
+
+        with patch.object(
+            AccountEdiFormat,
+            "_l10n_ec_get_edi_ws_client",
+            mock_l10n_ec_edi_zeep_client,
+        ), patch.object(
+            AccountEdiDocument,
+            "_l10n_ec_edi_send_xml_auth",
+            mock_l10n_ec_edi_send_xml_with_auth,
+        ), patch.object(
+            AccountEdiDocument,
+            "_l10n_ec_edi_process_response_auth",
+            mock_l10n_ec_edi_process_response_auth_cancelled,
+        ):
+            invoice.button_cancel_posted_moves()
+
+        self.assertEqual(edi_doc.state, "to_cancel")
+
+        cron_tasks = self.env.ref("account_edi.ir_cron_edi_network", False)
+        self.assertTrue(cron_tasks)
+        # Execute cron for cancel receipt
+        cron_tasks.method_direct_trigger()
+        self.assertEqual(invoice.state, "cancel")
+
+    def test_l10n_ec_authorized_to_cancelled_fail(self):
+        """
+        Create invoice, send to the SRI for authorize and unsuccessful cancelled
+        """
+
+        def mock_l10n_ec_edi_zeep_client(edi_doc_instance, environment, url_type):
+            return self._zeep_client_ws_sri()
+
+        def mock_l10n_ec_response_reception_received(
+            edi_doc_instance, client_ws, xml_signed
+        ):
+            return self._get_response_reception_received()
+
+        def mock_l10n_ec_edi_send_xml_with_auth(edi_doc_instance, client_ws):
+            return self._get_response_with_auth(edi_doc_instance)
+
+        partner = self.partner_with_email
+        self._setup_edi_company_ec()
+        invoice = self._l10n_ec_prepare_edi_out_invoice(
+            partner=partner, auto_post=False
+        )
+        invoice.action_post()
+        edi_doc = invoice._get_edi_document(self.edi_format)
+
+        # for authorize
+        with patch.object(
+            AccountEdiFormat,
+            "_l10n_ec_get_edi_ws_client",
+            mock_l10n_ec_edi_zeep_client,
+        ), patch.object(
+            AccountEdiDocument,
+            "_l10n_ec_edi_send_xml_auth",
+            mock_l10n_ec_edi_send_xml_with_auth,
+        ), patch.object(
+            AccountEdiDocument,
+            "_l10n_ec_edi_send_xml",
+            mock_l10n_ec_response_reception_received,
+        ):
+            edi_doc._process_documents_web_services(with_commit=False)
+
+        # Receipt is authorized
+        with patch.object(
+            AccountEdiFormat,
+            "_l10n_ec_get_edi_ws_client",
+            mock_l10n_ec_edi_zeep_client,
+        ), patch.object(
+            AccountEdiDocument,
+            "_l10n_ec_edi_send_xml_auth",
+            mock_l10n_ec_edi_send_xml_with_auth,
+        ), self.assertRaises(
+            ValidationError
+        ):
+            invoice.button_cancel_posted_moves()

--- a/l10n_ec_account_edi/tests/test_l10n_ec_mail.py
+++ b/l10n_ec_account_edi/tests/test_l10n_ec_mail.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import patch
 
 from odoo.tests import tagged
@@ -5,16 +6,30 @@ from odoo.tests import tagged
 from odoo.addons.l10n_ec_account_edi.models.account_edi_document import (
     AccountEdiDocument,
 )
+from odoo.addons.l10n_ec_account_edi.models.account_edi_format import AccountEdiFormat
 from odoo.addons.mail.tests.common import MailCommon
 
 from .test_edi_common import TestL10nECEdiCommon
+
+_logger = logging.getLogger(__name__)
 
 
 @tagged("post_install_l10n", "post_install", "-at_install", "mail")
 class TestL10nMail(TestL10nECEdiCommon, MailCommon):
     def test_l10n_ec_cron_invoice(self):
+        def mock_l10n_ec_edi_zeep_client(edi_doc_instance, environment, url_type):
+            _logger.warning("Mock -> _l10n_ec_get_edi_ws_client")
+            return self._zeep_client_ws_sri()
+
         def mock_l10n_ec_edi_send_xml_with_auth(edi_doc_instance, client_ws):
+            _logger.warning("Mock -> _l10n_ec_edi_send_xml_auth")
             return self._get_response_with_auth(edi_doc_instance)
+
+        def mock_l10n_ec_response_reception_received(
+            edi_doc_instance, client_ws, xml_signed
+        ):
+            _logger.warning("Mock -> _l10n_ec_edi_send_xml")
+            return self._get_response_reception_received()
 
         def mock_send_mail_to_partners(instance):
             # search company with environment test instead of production
@@ -34,12 +49,24 @@ class TestL10nMail(TestL10nECEdiCommon, MailCommon):
         )
         invoice.action_post()
         edi_doc = invoice._get_edi_document(self.edi_format)
+
         with patch.object(
-            AccountEdiDocument,
-            "_l10n_ec_edi_send_xml_auth",
-            mock_l10n_ec_edi_send_xml_with_auth,
+            AccountEdiFormat,
+            "_l10n_ec_get_edi_ws_client",
+            mock_l10n_ec_edi_zeep_client,
         ):
-            edi_doc._process_documents_web_services(with_commit=False)
+            with patch.object(
+                AccountEdiDocument,
+                "_l10n_ec_edi_send_xml_auth",
+                mock_l10n_ec_edi_send_xml_with_auth,
+            ):
+                with patch.object(
+                    AccountEdiDocument,
+                    "_l10n_ec_edi_send_xml",
+                    mock_l10n_ec_response_reception_received,
+                ):
+                    edi_doc._process_documents_web_services(with_commit=False)
+
         cron_tasks = self.env.ref(
             "l10n_ec_account_edi.ir_cron_send_email_electronic_documents", False
         )


### PR DESCRIPTION
Cancelar comprobantes autroizados del SRI. Primero se debe hacer el proceso de anulación en el SRI después se realiza la acción de cancelar documento EDI