### PR TITLE
[IMP] l10n_ec_withhold: invertir logica al evaluar si requiere o no r…

### DIFF
--- a/l10n_ec_withhold/models/account_fiscal_position.py
+++ b/l10n_ec_withhold/models/account_fiscal_position.py
@@ -4,7 +4,7 @@ from odoo import fields, models
 class AccountFiscalPosition(models.Model):
     _inherit = "account.fiscal.position"
 
-    l10n_ec_withhold = fields.Boolean(
-        string="Requires retentions ?",
-        help="Select if the tax position requires withholding",
+    l10n_ec_avoid_withhold = fields.Boolean(
+        string="Avoid Withholding?",
+        help="Select if the tax position no require withholding",
     )

--- a/l10n_ec_withhold/models/res_partner.py
+++ b/l10n_ec_withhold/models/res_partner.py
@@ -6,10 +6,8 @@ from .data import TAX_SUPPORT
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    l10n_ec_withhold_related = fields.Boolean(
-        string="Agente de retencion?",
-        help="Seleccionar si es agente de retencion",
-        related="property_account_position_id.l10n_ec_withhold",
+    l10n_ec_avoid_withhold = fields.Boolean(
+        related="property_account_position_id.l10n_ec_avoid_withhold",
     )
 
     l10n_ec_tax_support = fields.Selection(

--- a/l10n_ec_withhold/tests/__init__.py
+++ b/l10n_ec_withhold/tests/__init__.py
@@ -1,1 +1,2 @@
+from . import test_l10n_ec_edi_liquidation
 from . import test_l10n_ec_sale_withhold

--- a/l10n_ec_withhold/tests/test_l10n_ec_edi_liquidation.py
+++ b/l10n_ec_withhold/tests/test_l10n_ec_edi_liquidation.py
@@ -1,0 +1,38 @@
+from odoo.addons.l10n_ec_account_edi.tests.test_l10n_ec_edi_liquidation import (
+    TestL10nClDte,
+)
+
+# monkey patch for avoid errors on test because l10n_ec_tax_support is empty
+original_l10n_ec_create_form_move = TestL10nClDte._l10n_ec_create_form_move
+
+
+def _l10n_ec_create_form_move(
+    self,
+    move_type,
+    internal_type,
+    partner,
+    taxes=None,
+    products=None,
+    journal=None,
+    latam_document_type=None,
+    use_payment_term=False,
+    form_id=None,
+):
+    new_move_form = original_l10n_ec_create_form_move(
+        self,
+        move_type,
+        internal_type,
+        partner,
+        taxes,
+        products,
+        journal,
+        latam_document_type,
+        use_payment_term,
+        form_id,
+    )
+    if not new_move_form.l10n_ec_tax_support:
+        new_move_form.l10n_ec_tax_support = "01"
+    return new_move_form
+
+
+TestL10nClDte._l10n_ec_create_form_move = _l10n_ec_create_form_move

--- a/l10n_ec_withhold/tests/test_l10n_ec_sale_withhold.py
+++ b/l10n_ec_withhold/tests/test_l10n_ec_sale_withhold.py
@@ -17,11 +17,9 @@ class TestL10nSaleWithhold(TestL10nECEdiCommon):
     ):
         super().setUpClass(chart_template_ref=chart_template_ref)
         cls.WizardWithhold = cls.env["l10n_ec.wizard.create.sale.withhold"]
-        cls.position_withhold = cls.env["account.fiscal.position"].create(
-            {"name": "Withhold", "l10n_ec_withhold": True}
+        cls.position_no_withhold = cls.env["account.fiscal.position"].create(
+            {"name": "Withhold", "l10n_ec_avoid_withhold": True}
         )
-        cls.partner_with_email.property_account_position_id = cls.position_withhold
-        cls.partner_ruc.property_account_position_id = cls.position_withhold
 
     def get_tax_group_and_taxes(self):
         """
@@ -206,3 +204,9 @@ class TestL10nSaleWithhold(TestL10nECEdiCommon):
 
         with self.assertRaises(UserError):
             Form(self.WizardWithhold.with_context(active_ids=invoice.ids))
+
+    def test_l10n_ec_fail_when_invoice_no_require_withholding(self):
+        self.partner_ruc.property_account_position_id = self.position_no_withhold
+        invoice = self.get_invoice(self.partner_ruc)
+        with self.assertRaises(UserError):
+            invoice.action_try_create_ecuadorian_withhold()

--- a/l10n_ec_withhold/views/account_fiscal_position_view.xml
+++ b/l10n_ec_withhold/views/account_fiscal_position_view.xml
@@ -5,7 +5,7 @@
         <field name="inherit_id" ref="l10n_ec_base.account_fiscal_position_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='company_id']" position="after">
-                <field name="l10n_ec_withhold" />
+                <field name="l10n_ec_avoid_withhold" />
             </xpath>
         </field>
     </record>

--- a/l10n_ec_withhold/views/res_partner_view.xml
+++ b/l10n_ec_withhold/views/res_partner_view.xml
@@ -11,7 +11,7 @@
                 position="after"
             >
 
-                <field name="l10n_ec_withhold_related" />
+                <field name="l10n_ec_avoid_withhold" />
                 <field name="l10n_ec_tax_support" />
             </xpath>
         </field>


### PR DESCRIPTION
…etenciones

- antes de este commit, se debia configurar explicitamente en la posicion fiscal del contacto y de la compañia que va a usar retenciones lo cual es mas complicado. Si el usuario instala este modulo es xq va a usar retenciones, entonces con este commit se invierte la logica para que por defecto siempre pueda ingresar retenciones, pero cuando NO necesite aplicar retenciones por X razon, entonces recien ahi debera configurar en la posicion fiscal que NO debe usar retenciones